### PR TITLE
username changes and gemspec update

### DIFF
--- a/bin/conjur-ldap-sync
+++ b/bin/conjur-ldap-sync
@@ -31,6 +31,10 @@ class App
   options[:bind_password] = ENV['CONJUR_LDAP_PASSWORD']
   options[:format] = :json
   options[:mode] = :posix
+  options[:username] = :cn
+
+  on '--username ATTR', [:cn,:sAMAccountName],
+     'Use this attribute rather than CN for user name collection'
 
   on '--format FORMAT', [:text,:json],
      'Output format for reporting (text, json)'

--- a/conjur-ldap-sync.gemspec
+++ b/conjur-ldap-sync.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/conjurinc/ldap-sync"
 #   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = Dir.glob("{bin,lib,test,spec,features}/**/*")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]

--- a/lib/conjur/ldap/adapter/active_directory.rb
+++ b/lib/conjur/ldap/adapter/active_directory.rb
@@ -47,7 +47,7 @@ class Conjur::Ldap::Adapter
 
     def user_from_branch branch_hash
       uid = branch_hash['uidNumber'].to_i
-      cn =  branch_hash['cn']
+      cn =  branch_hash[options[:username]]
       dn = branch_hash['distinguishedName']
       user massage_cn(cn), dn, uid
     end


### PR DESCRIPTION
pull user names from sAMAccountName rather than the CN and remove the git command from the gemspec as it breaks non-git repos/nixos.